### PR TITLE
v5.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Consistent identifier (represents all versions, resolves to latest): [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.10055168.svg)](https://doi.org/10.5281/zenodo.10055168)
 
-## Unreleased - Date - DOI
+## v5.0.0
+
+Environment upgrades and minor patches
+
+### Changed
+
+* Upgraded to `treat-sim==3.0.0` so runnable with Python 3.12 and `streamlit==1.54.0`
+
+### Fixed
+
+* streanmlit's `st.image` now uses `width='stretch'` as opposed to `None` to avoid error.
+
+## v4.1.0
 
 Add choice of arrival profiles, or custom upload.
 

--- a/Overview.py
+++ b/Overview.py
@@ -44,7 +44,7 @@ with st.expander("View default arrival pattern", expanded=False):
 # the treatment process diagram
 st.markdown(overview_2)
 with st.expander("View treatment process", expanded=False):
-    st.image(PROCESS_IMG, width=None)
+    st.image(PROCESS_IMG, width="stretch")
     st.markdown(INFO_2)
 
 # Display info on using model to explore different scenarios

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,14 +2,14 @@ name: stars_streamlit
 channels:
   - conda-forge
 dependencies:
-  - matplotlib=3.7.1
-  - numpy=1.25.0
-  - pandas=2.0.2
-  - pip=21.0.1
-  - plotly=5.21.0
-  - python=3.10.13
-  - scipy=1.10.1
+  - matplotlib=3.10.8
+  - numpy=2.4.2
+  - pandas=2.3.3
+  - pip=26.0.1
+  - plotly=6.5.2
+  - python=3.12
+  - scipy=1.16.3
   - simpy=4.1.1
+  - streamlit=1.54.0
   - pip:
-    - streamlit==1.39.0
-    - treat-sim==2.2.0
+    - treat-sim==3.0.0

--- a/pages/0_🎱_Interactive_simulation.py
+++ b/pages/0_🎱_Interactive_simulation.py
@@ -221,7 +221,7 @@ st.title("Interactive simulation")
 st.markdown(INFO_1)
 with st.expander("Model recap", expanded=False):
     st.markdown(INFO_2)
-    st.image(PROCESS_IMG, width=None)
+    st.image(PROCESS_IMG, width="stretch")
 
 # Suggestion to vary parameters
 st.markdown(INFO_3)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-matplotlib>=3.7.1
-numpy==1.25.0
-pandas==2.0.2
-plotly==5.21.0
+matplotlib>=3.10
+numpy==1.26
+pandas==2.3.3
+plotly>6
 scipy==1.10.1
 simpy==4.1.1
-streamlit==1.39.0
-treat-sim==2.2.0
+streamlit==1.59.0
+treat-sim==3.0.0


### PR DESCRIPTION
Environment upgrades and minor patches

### Changed

* Upgraded to `treat-sim==3.0.0` so runnable with Python 3.12 and `streamlit==1.54.0`

### Fixed

* streanmlit's `st.image` now uses `width='stretch'` as opposed to `None` to avoid error.
